### PR TITLE
solve issue of low contrast

### DIFF
--- a/drismo/res/layout/archive.xml
+++ b/drismo/res/layout/archive.xml
@@ -29,7 +29,7 @@
         android:padding="20dp"
         android:gravity="center"
         android:textSize="25sp"
-        android:textColor="#ffffffff"
+        android:textColor="#282828"
         android:text="@string/noTripData"
         android:visibility="gone"
     />

--- a/drismo/res/layout/tutorial.xml
+++ b/drismo/res/layout/tutorial.xml
@@ -26,7 +26,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="30sp"
                       android:shadowColor="#001355"
                       android:shadowRadius="1.6"
@@ -47,7 +47,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
             <TextView android:id="@+id/tutorialTxt3"
@@ -58,7 +58,7 @@
                       android:paddingRight="20dp"
                       android:paddingBottom="10dp"
                       android:layout_marginTop="50dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
         </LinearLayout>
 

--- a/drismo/res/layout/tutorial1.xml
+++ b/drismo/res/layout/tutorial1.xml
@@ -26,7 +26,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="30sp"
                       android:shadowColor="#001355"
                       android:shadowRadius="1.6"
@@ -40,7 +40,7 @@
                       android:paddingTop="20dp"
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
         </LinearLayout>

--- a/drismo/res/layout/tutorial2.xml
+++ b/drismo/res/layout/tutorial2.xml
@@ -26,7 +26,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="30sp"
                       android:shadowColor="#001355"
                       android:shadowRadius="1.6"
@@ -40,7 +40,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:paddingTop="10dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
             <ImageView android:id="@+id/tutorialImg"
@@ -60,7 +60,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:paddingBottom="10dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
         </LinearLayout>

--- a/drismo/res/layout/tutorial3.xml
+++ b/drismo/res/layout/tutorial3.xml
@@ -27,7 +27,7 @@
                       android:paddingRight="20dp"
                       android:paddingBottom="10dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="30sp"
                       android:shadowColor="#001355"
                       android:shadowRadius="1.6"
@@ -50,7 +50,7 @@
                       android:paddingTop="10dp"
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
         </LinearLayout>

--- a/drismo/res/layout/tutorial4.xml
+++ b/drismo/res/layout/tutorial4.xml
@@ -26,7 +26,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="30sp"
                       android:shadowColor="#001355"
                       android:shadowRadius="1.6"
@@ -51,7 +51,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:paddingBottom="10dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
         </LinearLayout>

--- a/drismo/res/layout/tutorial5.xml
+++ b/drismo/res/layout/tutorial5.xml
@@ -26,7 +26,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="30sp"
                       android:shadowColor="#001355"
                       android:shadowRadius="1.6"
@@ -40,7 +40,7 @@
                       android:paddingTop="10dp"
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
             <ImageView android:id="@+id/tutorialImg"
@@ -59,7 +59,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:paddingBottom="10dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
         </LinearLayout>

--- a/drismo/res/layout/tutorial6.xml
+++ b/drismo/res/layout/tutorial6.xml
@@ -26,7 +26,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="30sp"
                       android:shadowColor="#001355"
                       android:shadowRadius="1.6"
@@ -51,7 +51,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:paddingBottom="10dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
         </LinearLayout>

--- a/drismo/res/layout/tutorial7.xml
+++ b/drismo/res/layout/tutorial7.xml
@@ -26,7 +26,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="30sp"
                       android:shadowColor="#001355"
                       android:shadowRadius="1.6"
@@ -47,7 +47,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:paddingBottom="10dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
         </LinearLayout>

--- a/drismo/res/layout/tutorial8.xml
+++ b/drismo/res/layout/tutorial8.xml
@@ -26,7 +26,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:gravity="center"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="30sp"
                       android:shadowColor="#001355"
                       android:shadowRadius="1.6"
@@ -40,7 +40,7 @@
                       android:paddingTop="10dp"
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
             <TextView android:id="@+id/tutorialTxt3"
                       android:text="@string/tutorialContent8_3"
@@ -48,7 +48,7 @@
                       android:layout_height="wrap_content"
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
             <TextView android:id="@+id/tutorialTxt4"
                       android:text="@string/tutorialContent8_4"
@@ -56,7 +56,7 @@
                       android:layout_height="wrap_content"
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
             <ImageView android:id="@+id/tutorialImg"
@@ -75,7 +75,7 @@
                       android:paddingLeft="20dp"
                       android:paddingRight="20dp"
                       android:paddingBottom="10dp"
-                      android:textColor="#ffffffff"
+                      android:textColor="#282828"
                       android:textSize="20sp" />
 
         </LinearLayout>


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#FFFFFF') and the background color ('#2A90FF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#282828') are as follows:
![image](https://user-images.githubusercontent.com/101503193/184944604-b0a7826d-c655-4db6-a02c-a901ba0c3e18.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.